### PR TITLE
Add logger to guzzle request

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ require './vendor/autoload.php';
 use RedsysConsultasPHP\Client\Client;
 
 $url = 'https://sis-t.redsys.es:25443/apl02/services/SerClsWSConsulta';
-$logger = new Logger('log');
+$logger = new \Monolog\Logger;('log');
 $logger->pushHandler(new \Monolog\Handler\RotatingFileHandler('dir_to_log/name_of_log.log'));
 $config = [
   'logger' => $logger,

--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ require './vendor/autoload.php';
 use RedsysConsultasPHP\Client\Client;
 
 $url = 'https://sis-t.redsys.es:25443/apl02/services/SerClsWSConsulta';
-$client = new Client($url, 'Introduce your merchant password');
+$logger = new Logger('log');
+$logger->pushHandler(new \Monolog\Handler\RotatingFileHandler('dir_to_log/name_of_log.log'));
+$config = [
+  'logger' => $logger,
+  'logger_format' => '{request}',
+];
+$client = new Client($url, 'Introduce your merchant password', $config);
 
 $order = 'Introduce your order';
 $terminal = 'Introduce your terminal';

--- a/examples/get_simple_transaction.php
+++ b/examples/get_simple_transaction.php
@@ -5,11 +5,17 @@ require '../vendor/autoload.php';
 use RedsysConsultasPHP\Client\Client;
 
 $url = 'https://sis-t.redsys.es:25443/apl02/services/SerClsWSConsulta';
-$client = new Client($url, 'Introduce your merchant password');
+$logger = new Logger('log');
+$logger->pushHandler(new \Monolog\Handler\RotatingFileHandler('dir_to_log/name_of_log.log'));
+$config = [
+    'logger' => $logger,
+    'logger_format' => '{request}',
+];
+$client = new Client($url, 'Introduce your merchant password', $config);
 
-$order = 'Introduce Ds_Order';
-$terminal = 'Introduce Ds_terminal';
-$merchant_code = 'Introduce your Ds_merchantCode';
+$order = 'Introduce your order';
+$terminal = 'Introduce your terminal';
+$merchant_code = 'Introduce your merchant code';
 $response = $client->getTransaction($order, $terminal, $merchant_code);
 
 print_r($response);

--- a/examples/get_simple_transaction.php
+++ b/examples/get_simple_transaction.php
@@ -5,7 +5,7 @@ require '../vendor/autoload.php';
 use RedsysConsultasPHP\Client\Client;
 
 $url = 'https://sis-t.redsys.es:25443/apl02/services/SerClsWSConsulta';
-$logger = new Logger('log');
+$logger = new \Monolog\Logger;('log');
 $logger->pushHandler(new \Monolog\Handler\RotatingFileHandler('dir_to_log/name_of_log.log'));
 $config = [
     'logger' => $logger,

--- a/examples/get_simple_transaction.php
+++ b/examples/get_simple_transaction.php
@@ -13,9 +13,9 @@ $config = [
 ];
 $client = new Client($url, 'Introduce your merchant password', $config);
 
-$order = 'Introduce your order';
-$terminal = 'Introduce your terminal';
-$merchant_code = 'Introduce your merchant code';
+$order = 'Introduce Ds_Order';
+$terminal = 'Introduce Ds_terminal';
+$merchant_code = 'Introduce your Ds_merchantCode';
 $response = $client->getTransaction($order, $terminal, $merchant_code);
 
 print_r($response);

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -50,7 +50,7 @@ class Client extends GuzzleClient
      *
      * Example config:
      * $config = [
-     *   'logger' => new \Monolog\Logger('log'),
+     *   'logger' => $logger,
      *   'logger_format' => '{request}',
      * ];
      * @see https://github.com/guzzle/guzzle/blob/master/src/MessageFormatter.php#L14

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -9,7 +9,6 @@ use RedsysConsultasPHP\Model\Transaction;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\MessageFormatter;
-use Monolog\Handler\RotatingFileHandler;
 use Psr\Log\LoggerInterface;
 
 /**


### PR DESCRIPTION
We need to log some request to get info about it.
We added an example of how to add a logger to the client.

Also you can add message format based on https://github.com/guzzle/guzzle/blob/master/src/MessageFormatter.php#L14

The logger configuration is optional.