### PR TITLE
Remove code and previous variables from custom redsys exception.

### DIFF
--- a/src/Client/RedsysException.php
+++ b/src/Client/RedsysException.php
@@ -18,7 +18,7 @@ class RedsysException extends \Exception {
     public function __construct($error_code)
     {
         $message = $this->getMessageInfo($error_code);
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message);
     }
 
     /**


### PR DESCRIPTION
Remove code and previous variables from custom redsys exception class because variables are not available in the construct.