### PR TITLE
Update guzzle to 7.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "ext-simplexml": "*",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^7.5"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "ext-simplexml": "*",
-        "guzzlehttp/guzzle": "^7.5"
+        "guzzlehttp/guzzle": "^6.3 || ^7"
     },
     "authors": [
         {


### PR DESCRIPTION
We're trying to update to guzzle to v7.5 (we use it in our project) and it's not possible as this dependency requires guzzle v6.5.

Can you upgrade it to the latest version? I've tested it pointing the project to my fork and it worked.